### PR TITLE
Hotfix

### DIFF
--- a/ScrollZoom.cs
+++ b/ScrollZoom.cs
@@ -59,7 +59,7 @@ public static class HudManager_Update_Patch
         if (PlayerControl.LocalPlayer == null)
             return false;
 
-        return PlayerControl.LocalPlayer.Data != null;
+        return ShipStatus.Instance != null;
     }
 
     private static void HandleScrollZoom()


### PR DESCRIPTION
Replaces the null check on PlayerControl.LocalPlayer.Data with a check on ShipStatus.Instance to determine if zoom handling should proceed.