### PR TITLE
Ensure plugins directory exists before copying DLL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Copy mod DLL into plugins
       run: |
+        if not exist output\x64\BepInEx\plugins mkdir output\x64\BepInEx\plugins
+        if not exist output\x86\BepInEx\plugins mkdir output\x86\BepInEx\plugins
         copy bin\Release\netstandard2.1\ScrollZoomMod.dll output\x64\BepInEx\plugins\
         copy bin\Release\netstandard2.1\ScrollZoomMod.dll output\x86\BepInEx\plugins\
 


### PR DESCRIPTION
Added commands to create the plugins directory for both x64 and x86 outputs if it does not already exist. This prevents errors when copying the ScrollZoomMod.dll during the build process.